### PR TITLE
Revert border overrides

### DIFF
--- a/source/wp-content/themes/wporg-make-2024/src/style/style.scss
+++ b/source/wp-content/themes/wporg-make-2024/src/style/style.scss
@@ -44,7 +44,3 @@ dl.glossary-list dt {
 .has-three-columns article {
 	--wp--style--global--content-size: 960px;
 }
-
-.wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper {
-	border-width: 0;
-}

--- a/source/wp-content/themes/wporg-make-2024/theme.json
+++ b/source/wp-content/themes/wporg-make-2024/theme.json
@@ -6,12 +6,6 @@
 			"color": {
 				"border": "var(--wp--preset--color--light-grey-1)"
 			},
-			"form": {
-				"border": {
-					"color": "var(--wp--preset--color--charcoal-5)",
-					"width": "1px"
-				}
-			},
 			"heading": {
 				"typography": {
 					"fontFamily": "var(--wp--preset--font-family--inter)",


### PR DESCRIPTION
Closes #55 

Removes border style overrides now that the [parent theme styles have been updated](https://github.com/WordPress/wporg-parent-2021/pull/169).