### PR TITLE
Fixing a null str_contains error

### DIFF
--- a/source/wp-content/themes/wporg-make-2024/functions.php
+++ b/source/wp-content/themes/wporg-make-2024/functions.php
@@ -582,7 +582,7 @@ add_shortcode(
 		$markdown_source = get_markdown_edit_link( $post->ID );
 		// If this is a github page, use the edit URL to generate the
 		// commit history URL
-		if ( isset($markdown_source) && str_contains( $markdown_source, 'github.com' ) ) {
+		if ( isset( $markdown_source ) && str_contains( $markdown_source, 'github.com' ) ) {
 			return str_replace( '/edit/', '/commits/', $markdown_source );
 		}
 		return '#';

--- a/source/wp-content/themes/wporg-make-2024/functions.php
+++ b/source/wp-content/themes/wporg-make-2024/functions.php
@@ -582,7 +582,7 @@ add_shortcode(
 		$markdown_source = get_markdown_edit_link( $post->ID );
 		// If this is a github page, use the edit URL to generate the
 		// commit history URL
-		if ( str_contains( $markdown_source, 'github.com' ) ) {
+		if ( isset($markdown_source) && str_contains( $markdown_source, 'github.com' ) ) {
 			return str_replace( '/edit/', '/commits/', $markdown_source );
 		}
 		return '#';


### PR DESCRIPTION
I've been testing the Handbook markdown importer wanted to check how it looks with the original theme, and found this deprecation error

`[16-Oct-2025 22:56:12 UTC] PHP Deprecated:  str_contains(): Passing null to parameter #1 ($haystack) of type string is deprecated in /var/www/src/wp-content/themes/wporg-make-2024/functions.php on line 586`

Happens in my localhost environment. Nothing big, but good to fix it.
