### PR TITLE
Run `[article_title]` shortcode through `do_shortcode()`.

### DIFF
--- a/source/wp-content/themes/wporg-make-2024/patterns/handbook-meta-github.php
+++ b/source/wp-content/themes/wporg-make-2024/patterns/handbook-meta-github.php
@@ -43,7 +43,7 @@
 				sprintf(
 					/* translators: %s: article title */
 					__( 'Improve it on GitHub<span class="screen-reader-text">: %s</span>', 'wporg' ),
-					'[article_title]'
+					do_shortcode( '[article_title]' )
 				)
 			); ?>
 		</a></p>
@@ -65,7 +65,7 @@
 				sprintf(
 					/* translators: %s: article title */
 					__( 'See list of changes<span class="screen-reader-text">: %s</span>', 'wporg' ),
-					'[article_title]'
+					do_shortcode( '[article_title]' )
 				)
 			); ?>
 		</a></p>

--- a/source/wp-content/themes/wporg-make-2024/patterns/handbook-meta-github.php
+++ b/source/wp-content/themes/wporg-make-2024/patterns/handbook-meta-github.php
@@ -43,7 +43,7 @@
 				sprintf(
 					/* translators: %s: article title */
 					__( 'Improve it on GitHub<span class="screen-reader-text">: %s</span>', 'wporg' ),
-					do_shortcode( '[article_title]' )
+					get_the_title()
 				)
 			); ?>
 		</a></p>
@@ -65,7 +65,7 @@
 				sprintf(
 					/* translators: %s: article title */
 					__( 'See list of changes<span class="screen-reader-text">: %s</span>', 'wporg' ),
-					do_shortcode( '[article_title]' )
+					get_the_title()
 				)
 			); ?>
 		</a></p>


### PR DESCRIPTION
This needs to happen because it's all passed through `sprintf`, which causes the literal text to be printed instead of the shortcode output. You can see this by inspecting the footer area where the article title is supposed to render with an edit link.

<img width="667" height="129" alt="image" src="https://github.com/user-attachments/assets/eb8dc4f5-4a47-4997-a9c3-321bd0570c18" />

The broken link is a separate matter, which comes down to meta key value. See https://github.com/WordPress/hosting-handbook/issues/340#issuecomment-3750475295. Question is: update the theme or fix the meta key names in wp-admin? 

Edit: I'm not sure this shortcode is registered anywhere. I don't see it in the theme, and the only other place I found it to be registered is in the 2023 developer theme here: https://github.com/WordPress/wporg-developer/blob/af552d561ba3e61d913e16ae9184de1d6aeb8a1e/source/wp-content/themes/wporg-developer-2023/inc/shortcodes.php#L64