### PR TITLE
Handbook: Fix null post warning in last_updated shortcode

### DIFF
--- a/source/wp-content/themes/wporg-make-2024/functions.php
+++ b/source/wp-content/themes/wporg-make-2024/functions.php
@@ -563,8 +563,7 @@ function add_handbook_templates( $templates ) {
 add_shortcode(
 	'article_edit_link',
 	function() {
-		global $post;
-		$markdown_source = get_markdown_edit_link( $post->ID );
+		$markdown_source = get_markdown_edit_link( get_post()->ID ?? 0 );
 		if ( $markdown_source ) {
 			return esc_url( $markdown_source );
 		}
@@ -578,8 +577,7 @@ add_shortcode(
 add_shortcode(
 	'article_changelog_link',
 	function() {
-		global $post;
-		$markdown_source = get_markdown_edit_link( $post->ID );
+		$markdown_source = get_markdown_edit_link( get_post()->ID ?? 0 );
 		// If this is a github page, use the edit URL to generate the
 		// commit history URL
 		if ( $markdown_source && str_contains( $markdown_source, 'github.com' ) ) {

--- a/source/wp-content/themes/wporg-make-2024/functions.php
+++ b/source/wp-content/themes/wporg-make-2024/functions.php
@@ -353,8 +353,8 @@ add_shortcode(
 	'last_updated',
 	function() {
 		$post = get_post();
-		if ( $post && get_the_modified_date( 'Ymdhi', $post ) > get_the_date( 'Ymdhi', $post ) ) {
-			return '<p style="font-style:normal;font-weight:700">' . esc_html__( 'Last updated', 'wporg' ) . '</p>';
+		if ( $post && get_post_modified_time( 'U', true, $post ) > get_post_time( 'U', true, $post ) ) {
+			return esc_html__( 'Last updated', 'wporg' );
 		}
 		return '';
 	}

--- a/source/wp-content/themes/wporg-make-2024/functions.php
+++ b/source/wp-content/themes/wporg-make-2024/functions.php
@@ -352,8 +352,8 @@ function modify_handbook_search_block_action( $block_content, $block ) {
 add_shortcode(
 	'last_updated',
 	function() {
-		global $post;
-		if ( get_the_modified_date( 'Ymdhi', $post->ID ) > get_the_date( 'Ymdhi', $post->ID ) ) {
+		$post = get_post();
+		if ( $post && get_the_modified_date( 'Ymdhi', $post ) > get_the_date( 'Ymdhi', $post ) ) {
 			return '<p style="font-style:normal;font-weight:700">' . esc_html__( 'Last updated', 'wporg' ) . '</p>';
 		}
 		return '';

--- a/source/wp-content/themes/wporg-make-2024/patterns/handbook-meta.php
+++ b/source/wp-content/themes/wporg-make-2024/patterns/handbook-meta.php
@@ -23,7 +23,7 @@
 	<!-- wp:group {"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"constrained"}} -->
 	<div class="wp-block-group">
 		<!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}}} -->
-		<p style="font-style:normal;font-weight:700">[last_updated]</p>
+		<p style="font-style:normal;font-weight:700"><?php echo do_shortcode( '[last_updated]' ); ?></p>
 		<!-- /wp:paragraph -->
 
 		<!-- wp:post-date {"displayType":"modified"} /-->

--- a/source/wp-content/themes/wporg-make-2024/patterns/handbook-meta.php
+++ b/source/wp-content/themes/wporg-make-2024/patterns/handbook-meta.php
@@ -23,7 +23,7 @@
 	<!-- wp:group {"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"constrained"}} -->
 	<div class="wp-block-group">
 		<!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}}} -->
-		<p style="font-style:normal;font-weight:700"><?php echo do_shortcode( '[last_updated]' ); ?></p>
+		<p style="font-style:normal;font-weight:700">[last_updated]</p>
 		<!-- /wp:paragraph -->
 
 		<!-- wp:post-date {"displayType":"modified"} /-->


### PR DESCRIPTION
## What

Fixes a PHP warning (`Attempt to read property "ID" on null` in `wporg-make-2024/functions.php:356`) that is triggered when the block editor resolves a handbook template via the `wp/v2/templates/lookup` REST endpoint.

## Why

The `last_updated` shortcode dereferenced `global $post` without checking that one exists. Since WordPress 6.6, template resolution inlines `wp:pattern` blocks by evaluating the pattern PHP files (`resolve_pattern_blocks()`), and `patterns/handbook-meta.php` called `do_shortcode( '[last_updated]' )` at that point. In a REST template lookup there is no main query and no global post, so the shortcode ran with a `null` post.

Evaluating the shortcode while the pattern is being built is also incorrect on its own: the result gets baked into the resolved template content based on whatever post happens to be global at that moment, instead of the post actually being rendered.

## How

- `functions.php`: use `get_post()` and only compare dates when a post is available, short-circuiting to an empty string otherwise.
- `patterns/handbook-meta.php`: output the raw `[last_updated]` shortcode instead of evaluating it in the pattern file, so it renders against the actual post at render time — matching what `handbook-meta-github.php` already does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)